### PR TITLE
feat: add reference to NeSC course

### DIFF
--- a/episodes/01-introduction.md
+++ b/episodes/01-introduction.md
@@ -249,6 +249,7 @@ The expected out put of each command is:
 
 We recommend the following resources for some additional reading on reproducible research:
 
+* [Reproducible research through reusable code][nesc-ttw-guide-reproducible-research] is a one day course by the [Netherlands eScience Center][nesc] which discusses similar themes to this course, but in a shorter format.
 * [The Turing Way's "Guide for Reproducible Research"][ttw-guide-reproducible-research]
 * [A Beginner's Guide to Conducting Reproducible Research][beginner-guide-reproducible-research], Jesse M. Alston, Jessica A. Rick, Bulletin of The Ecological Society of America 102 (2) (2021), https://doi.org/10.1002/bes2.1801
 * ["Ten reproducible research things" tutorial][10-reproducible-research-things]

--- a/learners/reference.md
+++ b/learners/reference.md
@@ -9,6 +9,8 @@ Please check our [jargon busting](episodes/00-introduction.html#jargon-busting) 
 ## Reference and further reading {#litref}
 The content of this course borrows from or references the following work, which we also recommend for further reading.
 
+- [Reproducible research through reusable code][nesc-ttw-guide-reproducible-research] is a one day course by the [Netherlands eScience Center][nesc] which discusses similar themes to this course, but in a shorter format.
+
 - [A Beginner's Guide to Conducting Reproducible Research][beginner-guide-reproducible-research], 
 Jesse M. Alston, Jessica A. Rick, Bulletin of The Ecological Society of America 102 (2) (2021), https://doi.org/10.1002/bes2.1801
 

--- a/links.md
+++ b/links.md
@@ -136,3 +136,5 @@ any links that you are not going to use.
 [codemeta]: https://codemeta.github.io/
 [docker]: https://www.docker.com/
 [bitbucket]: https://bitbucket.org/
+[nesc-ttw-guide-reproducible-research]: https://carpentries-incubator.github.io/reproducible-research-through-reusable-code-in-1-day
+[nesc]: https://www.esciencecenter.nl


### PR DESCRIPTION
- Add reference to NeSC course in episode 1 and `reference.md`
- `reference.md` gives a 404 currently while accessing from the bottom of any episode (URL: `http://127.0.0.1:4321/reference.html#litref`), not sure why, seems to be rendering fine on the original lesson in `main`, but has issues on local deployment 